### PR TITLE
fw/b torch: Let long press power turn torch off when screen is on.

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -1523,7 +1523,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         if (FactoryTest.isLongPressOnPowerOffEnabled()) {
             return LONG_PRESS_POWER_SHUT_OFF_NO_CONFIRM;
         }
-        if (mTorchLongPressPowerEnabled && (!isScreenOn() || isDozeMode())) {
+        if (mTorchLongPressPowerEnabled && (!isScreenOn() || isDozeMode() || mTorchEnabled)) {
             return LONG_PRESS_POWER_TORCH;
         }
         return mLongPressOnPowerBehavior;


### PR DESCRIPTION
* When the torch is on, any subsequent long press power is almost certainly
  intended to turn the torch off (regardless of screen state).  Therefore,
  always allow long press power to toggle torch if the torch is on.

* Tested: long press power toggles torch on/off with screen off.
          long press power toggles torch off with screen on and torch on.
          long press power brings up global actions menu with screen on and torch off.

Change-Id: I932caa9f3be06d14408aea2ecb3a6eca73e052e0