### PR TITLE
LockSettingsService : Restrict access to getpassword API

### DIFF
--- a/services/core/java/com/android/server/locksettings/LockSettingsService.java
+++ b/services/core/java/com/android/server/locksettings/LockSettingsService.java
@@ -1179,7 +1179,7 @@ public class LockSettingsService extends ILockSettings.Stub {
          */
        if (checkCryptKeeperPermissions())
             mContext.enforceCallingOrSelfPermission(
-                    android.Manifest.permission.MANAGE_DEVICE_ADMINS,
+                    android.Manifest.permission.ACCESS_KEYGUARD_SECURE_STORAGE,
                     "no crypt_keeper or admin permission to get the password");
 
        return mSavePassword;


### PR DESCRIPTION
Restrict Permission of getpassword API to ACCESS_KEYGUARD_SECURE_
STORAGE to ensure saftey for user credentials. No process without
this permission should be able to invoke this API from locksetting
aidl.

CRs-Fixed: 2576302
Change-Id: I7085a00acbdb3e0ea246210207e83c80ab48dc38
Signed-off-by: Prerna Kalla <prernak@codeaurora.org>